### PR TITLE
Fix file format validation

### DIFF
--- a/features/validator.feature
+++ b/features/validator.feature
@@ -30,6 +30,16 @@ Feature: file format validation
       |      t.bam |         bam |            VALID |
       |      t.txt |         txt |            VALID |
 
+  Scenario Outline: 1.c valid fastq file, but file format is invalid - does not point to fastq validation
+    Given a valid file with filename <file_name>
+    And format field set to <file_format>
+    When metadata is validated
+    Then File is <validation_state> after validation
+
+    Examples:
+      |   file_name | file_format | validation_state |
+      | abc.file.fq | abc.file.fq |          INVALID |
+
   Scenario Outline: 2.a.1 valid fastq file - filename extension doesn't match the file format - both point to fastq validator
     Given a valid file with filename <file_name>
     And format field set to <file_format>
@@ -147,7 +157,7 @@ Feature: file format validation
       |   file.fastq.tar.gz |    xfastq.tar.gz |          INVALID |
       |             file.fq |              xfq |          INVALID |
 
-  Scenario Outline: 4 - invalid file whose file format is prepended by dot
+  Scenario Outline: 4.a - invalid file whose file format is prepended by dot
     Given an invalid file with filename <file_name>
     And format field set to <file_format>
     When metadata is validated
@@ -161,7 +171,7 @@ Feature: file format validation
       |   file.fastq.tar.gz |    .fastq.tar.gz |          INVALID |
       |             file.fq |              .fq |          INVALID |
 
-  Scenario Outline: 4 - valid file whose file format has a leading dot
+  Scenario Outline: 4.b - valid file whose file format has a leading dot
     Given a valid file with filename <file_name>
     And format field set to <file_format>
     When metadata is validated

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ingest-validator",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Ingest validator implementation in node using ajv based on https://github.com/HumanCellAtlas/ingest-validator.git which is in turn based on https://github.com/EMBL-EBI-SUBS/json-schema-validator.git.",
   "main": "dist/app.js",
   "repository": "https://github.com/ebi-ait/ingest-validator.git",

--- a/src/listener/handlers/document-update-handler.ts
+++ b/src/listener/handlers/document-update-handler.ts
@@ -158,10 +158,8 @@ class DocumentUpdateHandler implements IHandler {
 
                     const acceptedFileFormatForValidation = Object.keys(config.get("FILE_VALIDATION_IMAGES"));
 
-                    if ((fileFormat && !fileFormat.match(/^[a-zA-Z]/))
-                        || (!fileName.endsWith(fileFormat) && fileFormat)
-                        || (fileFormat && !acceptedFileFormatForValidation.includes(fileFormat)
-                            && this.filenameMatchingFastqFilePattern(fileName, acceptedFileFormatForValidation))) {
+                    if (this.isInvalidFileExtension(fileFormat, fileName)
+                        || this.isInvalidFileFormat(fileFormat, fileName, acceptedFileFormatForValidation)) {
                         const msg = `The file with filename, "${fileName}", doesn't match the file format, "${fileFormat}", in the metadata.`;
                         contentValidationReport.addError(ErrorType.MetadataError, msg, msg)
                     }
@@ -179,6 +177,17 @@ class DocumentUpdateHandler implements IHandler {
                 });
         }
         return Promise.resolve(contentValidationReport); // return original report if not eligible for file validation
+    }
+
+    private isInvalidFileExtension(fileFormat: string, fileName: string): boolean {
+        return !!(!fileName.endsWith(fileFormat) && fileFormat);
+    }
+
+    private isInvalidFileFormat(fileFormat: string, fileName: string, acceptedFileFormatForValidation: string[]): boolean {
+        return !!(fileFormat
+                    && !acceptedFileFormatForValidation.includes(fileFormat)
+                    && this.filenameMatchingFastqFilePattern(fileName, acceptedFileFormatForValidation)
+        );
     }
 
     private filenameMatchingFastqFilePattern(fileName: string, fastqFormat: string[]): boolean {


### PR DESCRIPTION
 ebi-ait/dcp-ingest-central#324

Changes:
- Extension checking replaced by `endsWith` checking
- if file by its name looks like a fastq file, but file format is not valid, then validation status is invalid
- file format should start with a letter, otherwise it is invalid