### PR TITLE
Feature/mc-60 morphic validator

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -56,5 +56,9 @@
     "fastq" : "quay.io/humancellatlas/fastq_utils:v0.1.0.rc",
     "fastq.gz" : "quay.io/humancellatlas/fastq_utils:v0.1.0.rc",
     "fastq.tar.gz" : "quay.io/humancellatlas/fastq_utils:v0.1.0.rc"
+  },
+  "BIOVALIDATOR_API": {
+    "baseUrl": "https://www.ebi.ac.uk/ait/biovalidator",
+    "endpoint": "/validate"
   }
 }

--- a/src/validation/ingest-validator.spec.ts
+++ b/src/validation/ingest-validator.spec.ts
@@ -42,36 +42,123 @@ describe("Ingest validator tests", () =>{
             })
     });
 
-    it("should use Biovalidator for JSON Schema Draft 2019",  () => {
+    describe("Ingest Biovalidator tests", () => {
+        const draft2019Schema = {
+            "$schema": "http://json-schema.org/draft-2019-09/schema",
+            "required": ["schema_type", "schema_version", "submissionDate", "user", "updateDate", "lastModifiedUser", "uuid", "content"],
+            "properties": {
+                "schema_type": {"type": "string"},
+                "schema_version": {"type": "string"},
+                "submissionDate": {"format": "date-time"},
+                "user": {"type": "string"},
+                "updateDate": {"format": "date-time"},
+                "lastModifiedUser": {"type": "string"},
+                "uuid": {"type": "string"},
+                "content": {"type": "object"}
+            }
+        };
+
         const schemaValidatorMock: TypeMoq.IMock<SchemaValidator> = TypeMoq.Mock.ofType<SchemaValidator>();
         const ingestClientMock: TypeMoq.IMock<IngestClient> = TypeMoq.Mock.ofType<IngestClient>();
 
-        const draft2019Schema = {
-            "$schema": "http://json-schema.org/draft-2019-09/schema",
-            "properties": {
-                "testProperty": {
-                    "type": "string"
+        beforeEach(() => {
+            ingestClientMock
+                .setup(mockInstance => mockInstance.fetchSchema(TypeMoq.It.isAnyString()))
+                .returns(() => Promise.resolve(draft2019Schema));
+        });
+
+        it("should use Biovalidator for JSON Schema Draft 2019",  () => {
+            const document = {
+                "content": {
+                    "testProperty": "testValue",
+                    "describedBy": "http://example.com/schema"
                 }
-            }
-        };
+            };
 
-        ingestClientMock
-            .setup(mockInstance => mockInstance.fetchSchema(TypeMoq.It.isAnyString()))
-            .returns(() => Promise.resolve(draft2019Schema));
+            const ingestValidator = new IngestValidator(schemaValidatorMock.object, ingestClientMock.object);
 
-        const document = {
-            "content": {
-                "testProperty": "testValue",
-                "describedBy": "http://example.com/schema"
-            }
-        };
+            return ingestValidator.validate(document, "testDocumentType")
+                .then(validationReport => {
+                    expect(validationReport).toBeDefined();
+                });
+        });
 
-        const ingestValidator = new IngestValidator(schemaValidatorMock.object, ingestClientMock.object);
+        it("should identify missing required fields using Biovalidator", () => {
+            const documentWithMissingFields = {
+                "described_by": "http://example.com/schema",
+                "schema_type": "testType", // assuming other required fields are missing
+                "content": {
+                }
+            };
 
-        // Now using the then() method for promise chaining
-        return ingestValidator.validate(document, "testDocumentType")
-            .then(validationReport => {
-                expect(validationReport).toBeDefined();
-            });
+            const ingestValidator = new IngestValidator(schemaValidatorMock.object, ingestClientMock.object);
+
+            return ingestValidator.validate(documentWithMissingFields, "testDocumentType")
+                .catch(validationReport => {
+                    expect(validationReport.validationState).toBe("INVALID");
+                    expect(validationReport.errors).toContain("Missing required fields");
+                });
+        });
+
+        it("should validate successfully when all required fields are provided", () => {
+            const completeDocument = {
+                "described_by": "https://schema.morphic.bio/type/project/0.0.1/study",
+                "schema_type": "study",
+                "schema_version": "1.0.0",
+                "submissionDate": "2022-04-01",
+                "user": "exampleUser",
+                "updateDate": "2022-04-02",
+                "lastModifiedUser": "exampleUser",
+                "uuid": "1234-5678-9012-3456",
+                "content": {
+                    "biological_sample_types": [
+                        "embryoid body"
+                    ],
+                    "cell_line_names": [
+                        "KOLF2.2J"
+                    ],
+                    "contact_emails": [
+                        "fakemail@123.com"
+                    ],
+                    "contact_first_name": "Bob",
+                    "contact_surname": "Lorem Ipsum",
+                    "dracc_data_sharing_date": "2018-11-13",
+                    "duo_codes": [
+                        "DUO:0000046"
+                    ],
+                    "institute": "NWU",
+                    "label": "ThisIsAStudyExample",
+                    "model_organ_systems": [
+                        "UBERON:0000006"
+                    ],
+                    "other_comments": "This is not a comment",
+                    "perturbation_type": [
+                        "irreversible gene knockout"
+                    ],
+                    "readout_assay": "EFO:0008931",
+                    "sequencing_platforms": [
+                        "OBI:0002002"
+                    ],
+                    "study_description": "Lorem ipsum dolor sit amet",
+                    "supplementary_links": [
+                        "https://medlineplus.gov/genetics/gene/pax2/"
+                    ],
+                    "target_genes": [
+                        "PAX2"
+                    ]
+                }
+            };
+
+            const ingestValidator = new IngestValidator(schemaValidatorMock.object, ingestClientMock.object);
+
+            return ingestValidator.validate(completeDocument, "testDocumentType")
+                .catch(validationReport => {
+                    expect(validationReport.validationState).toBe("VALID");
+                    expect(validationReport.errors).toEqual([]); // Expect no errors
+                });
+        });
+
     });
+
+
 });

--- a/src/validation/ingest-validator.spec.ts
+++ b/src/validation/ingest-validator.spec.ts
@@ -41,4 +41,26 @@ describe("Ingest validator tests", () =>{
                 expect(rep.validationState).toBe("INVALID");
             })
     });
+
+    it("should return an INVALID ValidationReport when describedBy schema can't be retrieved", () => {
+        const mockSchemaValidator: TypeMoq.IMock<SchemaValidator> = TypeMoq.Mock.ofType<SchemaValidator>();
+        const mockIngestClient: TypeMoq.IMock<IngestClient> = TypeMoq.Mock.ofType<IngestClient>();
+
+        const badUrl = "badUrl";
+        mockIngestClient
+            .setup(mockInstance => mockInstance.fetchSchema(TypeMoq.It.isValue(badUrl)))
+            .returns(() => Promise.reject(new Error()));
+
+        const ingestValidator = new IngestValidator(mockSchemaValidator.object, mockIngestClient.object);
+        const documentErroneousDescribedBy: object = {
+            "content": {
+                "describedBy": "badUrl"
+            }
+        };
+
+        ingestValidator.validate(documentErroneousDescribedBy, "someDocumentType")
+            .then((rep: ValidationReport) => {
+                expect(rep.validationState).toBe("INVALID");
+            })
+    });
 });

--- a/src/validation/ingest-validator.ts
+++ b/src/validation/ingest-validator.ts
@@ -11,6 +11,8 @@ import ErrorReport from "../model/error-report";
 import {NoDescribedBy, SchemaRetrievalError} from "./ingest-validation-exceptions";
 import R from "ramda";
 import ErrorType from "../model/error-type";
+import request from "request-promise";
+import config from "config";
 
 /**
  *
@@ -22,11 +24,15 @@ class IngestValidator {
     schemaValidator: SchemaValidator;
     ingestClient: IngestClient;
     schemaCache: any;
+    baseUrl: string;
+    endpoint: string;
 
     constructor(schemaValidator: SchemaValidator, ingestClient: IngestClient) {
         this.schemaValidator = schemaValidator;
         this.ingestClient = ingestClient;
         this.schemaCache = {};
+        this.baseUrl = config.get("BIOVALIDATOR_API.baseUrl");
+        this.endpoint = config.get("BIOVALIDATOR_API.endpoint");
     }
 
     validate(document: any, documentType: string) : Promise<ValidationReport> {
@@ -38,13 +44,19 @@ class IngestValidator {
 
             return this.getSchema(schemaUri)
                 .then(schema => {return IngestValidator.insertSchemaId(schema)})
-                .then(schema => {return this.schemaValidator.validateSingleSchema(schema, documentContent)})
-                .then(valErrors => {return IngestValidator.parseValidationErrors(valErrors)})
-                .then(parsedErrors => {return IngestValidator.generateValidationReport(parsedErrors)})
+                .then(schema => {
+                    if (this.shouldUseBiovalidator(schema)) {
+                        return this.validateWithBiovalidatorAndGenerateReport(schema, documentContent);
+                    } else {
+                        return this.schemaValidator.validateSingleSchema(schema, documentContent)
+                            .then(valErrors => {return IngestValidator.parseValidationErrors(valErrors)})
+                            .then(parsedErrors => {return IngestValidator.generateValidationReport(parsedErrors)})
+                    }
+                })
                 .catch(SchemaRetrievalError, err => {
                     const errReport = new ErrorReport(ErrorType.MetadataError, `Failed to retrieve schema at ${schemaUri}`);
                     return Promise.resolve(ValidationReport.invalidReport([errReport]));
-                })
+                });
         }
     }
 
@@ -90,6 +102,72 @@ class IngestValidator {
         }
 
         return Promise.resolve(report);
+    }
+
+    shouldUseBiovalidator(schema: any): boolean {
+        // Implement logic to decide based on schema (e.g., checking $schema value for draft-07 or later)
+        return schema['$schema'] && schema['$schema'].includes('2019');
+    }
+
+    private validateWithBiovalidatorAndGenerateReport(schema: any, documentContent: any): Promise<ValidationReport> {
+        console.log("Found JSON Schema Draft 2019 - Using Biovalidator for validation");
+        return this.validateWithBiovalidator(schema, documentContent)
+            .then(biovalidatorResponse => {
+                const errorReports = IngestValidator.parseBiovalidatorErrors(biovalidatorResponse);
+                this.reportValidationErrors(errorReports);
+                return IngestValidator.generateValidationReport(errorReports);
+            })
+            .catch(err => {
+                return Promise.resolve(ValidationReport.invalidReport([
+                    new ErrorReport(ErrorType.MetadataError, "Failed to validate with Biovalidator")
+                ]));
+            });
+    }
+
+    validateWithBiovalidator(schema: any, documentContent: any): Promise<any> {
+        const payload = {
+            schema: {
+                properties: schema['properties']
+            },
+            data: {
+                content: documentContent
+            },
+        };
+
+        return new Promise<any>((resolve, reject) => {
+            const options = {
+                method: "POST",
+                url: `${this.baseUrl}${this.endpoint}`, // Constructing the full URL
+                body: payload,
+                json: true,
+            };
+
+            request(options)
+                .then(resp => resolve(resp))
+                .catch(err => reject(err));
+        });
+    }
+
+    static parseBiovalidatorErrors(errors: any[]): ErrorReport[] {
+        return errors.map(err => {
+            // Combine all errors into a single message for simplicity
+            const message = err.errors.join("; ");
+            return new ErrorReport(ErrorType.MetadataError, message, err.dataPath);
+        });
+    }
+
+    private reportValidationErrors(errorReports: ErrorReport[]): void {
+        if (errorReports.length > 0) {
+            console.error('Validation Errors:');
+            errorReports.forEach(report => {
+                let errorMessage = `-`;
+                if (report.userFriendlyMessage) {
+                    errorMessage += ` ${report.userFriendlyMessage}`;
+                }
+                errorMessage += ` ${report.message}`
+                console.error(errorMessage);
+            });
+        }
     }
 
 }


### PR DESCRIPTION
**Things done in this PR:**

- Utilized Biovalidator API to support metadata validation against the Study schema specifically tailored for the MorPhiC project.
- Configured Biovalidator to validate against JSON Schema Draft 2019, ensuring compliance with schema standards. Validation against other schema versions continues to rely on existing logic designed for HCA.
- Implemented logic to validate system-related properties in the Study schema, ensuring alignment with those managed by ingest-core.
- Configured environment variables for the Biovalidator API.
- Added test cases to validate the effectiveness of the Biovalidator integration and the newly implemented descriptive fields within our validation framework.


See: https://github.com/morphic-bio/data-ingestion-development/issues/60
https://github.com/morphic-bio/data-ingestion-development/issues/62